### PR TITLE
Error handling + PUT method lost

### DIFF
--- a/lib/ewdliteclient.js
+++ b/lib/ewdliteclient.js
@@ -228,7 +228,9 @@ module.exports = {
     req.on('error', function(error) {
       if (callback && !req.timedOut) {
         try {
-          callback(JSON.parse(error));
+         // bug fix: removed parsing because error is an object, so callback gets proper error details
+         // previously you got unknown errors on "connect ETIMEDOUT"
+          callback(error);
         }
         catch (err) {
           console.log("ewdliteclient error: " + err + "; returned error = " + error);
@@ -242,7 +244,7 @@ module.exports = {
       req.timedOut = true;
       if (callback) callback('serverTimeout');
     });
-    if (method === 'POST') req.write(post_data);
+    if ((method === 'POST') || (method === 'PUT')) req.write(post_data);
     req.end();
     return;
   },


### PR DESCRIPTION
If a connection error occurs, the error object is returned completely now (error object was parsed before).

The PUT method had disappeared and the body content was not written out in the request.
